### PR TITLE
Path for include file (partial) must be refereed from parent template path

### DIFF
--- a/src/main/java/net/wouterdanes/MustacheMojo.java
+++ b/src/main/java/net/wouterdanes/MustacheMojo.java
@@ -89,7 +89,7 @@ public class MustacheMojo extends AbstractMojo {
         Mustache mustache = createTemplate(configuration.getTemplateFile(), charset);
         File outputFile = new File(configuration.getOutputPath());
         File parent = outputFile.getParentFile();
-        if (!parent.exists() || parent.mkdirs()) {
+        if (!parent.exists() && parent.mkdirs()) {
             throw new MojoFailureException("Output directory cannot be created.");
         }
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(outputFile), charset)) {
@@ -147,7 +147,7 @@ public class MustacheMojo extends AbstractMojo {
     }
 
     private static Mustache createTemplate(File template, Charset charset) throws MojoFailureException {
-        DefaultMustacheFactory mf = new DefaultMustacheFactory();
+        DefaultMustacheFactory mf = new DefaultMustacheFactory(template.getParentFile());
         Mustache mustache;
         try (Reader reader = new InputStreamReader(new FileInputStream(template), charset)) {
             mustache = mf.compile(reader, "template");

--- a/src/test/java/net/wouterdanes/MustacheMojoTest.java
+++ b/src/test/java/net/wouterdanes/MustacheMojoTest.java
@@ -190,6 +190,6 @@ public class MustacheMojoTest {
 
         String output = new String(fileContents);
 
-        assertEquals("Output not the expected output", "Hello test", output);
+        assertEquals("Output not the expected output", "Hello test\ninclude: Hello test", output);
     }
 }

--- a/src/test/resources/includes/includeFile.mustache
+++ b/src/test/resources/includes/includeFile.mustache
@@ -1,0 +1,1 @@
+include: {{text}}

--- a/src/test/resources/test-template.mustache
+++ b/src/test/resources/test-template.mustache
@@ -1,1 +1,2 @@
 {{text}}
+{{> includes/includeFile.mustache}}


### PR DESCRIPTION
When you use the plugin with a template that has partials included, the partial must be referenced from the directory of parent template. 
With the previous behaviour, the partial needs to be included with a path relative from maven execution point.

By example.
Correct behaviour:
 {{> includes/includeFile.mustache}}
Previous behaviour:
  {{> src/resources/includes/includeFile.mustache}}